### PR TITLE
Support for UnstakeTxn, Routing Txn Fixes and Test Fixes

### DIFF
--- a/examples/first_block.rs
+++ b/examples/first_block.rs
@@ -24,7 +24,7 @@ async fn find_first_block(client: &Client) -> u64 {
                 current_height = last_safe_height - 1;
                 match blocks::get(&client, &current_height).await {
                     Ok(b) => b,
-                    Err(e) => panic!("error getting block: {}", current_height),
+                    Err(e) => panic!("error getting block {}: {}", current_height, e),
                 }
             }
         };

--- a/examples/latest_challenge.rs
+++ b/examples/latest_challenge.rs
@@ -18,14 +18,14 @@ async fn main() {
 
         let txns = block_raw.transactions;
 
-        for tx_hash in txns.iter() {
-            let _tx = match transactions::get(&client, tx_hash).await {
+        for txn in txns.iter() {
+            let _tx = match transactions::get(&client, &txn.hash).await {
                 Ok(tx) => match tx {
                     Transaction::PocRequestV1 { challenger, .. } => {
                         if challenger == gateway {
                             println!(
                                 "Most recent challenge issued at block {}. tx {}",
-                                current_height, tx_hash
+                                current_height, txn.hash
                             );
                             return;
                         }
@@ -34,7 +34,7 @@ async fn main() {
                     _ => Ok(()),
                 },
                 Err(e) => {
-                    println!("Error with txn: {}: {:?}", tx_hash, e);
+                    println!("Error with txn: {}: {:?}", txn.hash, e);
                     Err(e)
                 }
             };

--- a/examples/transaction_types.rs
+++ b/examples/transaction_types.rs
@@ -1,44 +1,56 @@
-use helium_jsonrpc::{Client, transactions, transactions::Transaction};
+use helium_jsonrpc::{transactions, transactions::Transaction, Client};
 
 #[tokio::main]
 async fn main() {
     let client = Client::default();
 
-
-    let tx = transactions::get(&client, "bDd-yA7MWLDlowyPTC96QEspnqzUKEg6yroL8G9dDQk").await.unwrap();
+    let tx = transactions::get(&client, "bDd-yA7MWLDlowyPTC96QEspnqzUKEg6yroL8G9dDQk")
+        .await
+        .unwrap();
     match tx {
-        Transaction::VarsV1{ .. } => println!("VarsV1"),
+        Transaction::VarsV1 { .. } => println!("VarsV1"),
         _ => println!("Didn't find VarsV1"),
     }
 
-    let state_channel_close = transactions::get(&client, "-j71ACV87GyyRylytzfZJlqtkyvSYwJGb8P72UREL6E").await.unwrap();
+    let state_channel_close =
+        transactions::get(&client, "-j71ACV87GyyRylytzfZJlqtkyvSYwJGb8P72UREL6E")
+            .await
+            .unwrap();
     match state_channel_close {
         Transaction::StateChannelCloseV1 { .. } => println!("StateChannelCloseV1"),
         _ => println!("Didn't find StateChannelCloseV1"),
     }
 
-    let state_channel_open_v1 = transactions::get(&client, "I0pTZ1yLLt58Y7ox8MGGEzqyqqDm0An5CFaLrkuz5Ks").await.unwrap();
+    let state_channel_open_v1 =
+        transactions::get(&client, "I0pTZ1yLLt58Y7ox8MGGEzqyqqDm0An5CFaLrkuz5Ks")
+            .await
+            .unwrap();
     match state_channel_open_v1 {
         Transaction::StateChannelOpenV1 { .. } => println!("StateChannelOpenV1"),
         _ => println!("Didn't find StateChannelOpenV1"),
     }
 
-    let token_burn_v1 = transactions::get(&client, "5HyVcJIFIDEPQYBmc8OxeGxolkAdt8jfqPZYRsSi7BA").await.unwrap();
+    let token_burn_v1 = transactions::get(&client, "5HyVcJIFIDEPQYBmc8OxeGxolkAdt8jfqPZYRsSi7BA")
+        .await
+        .unwrap();
     match token_burn_v1 {
         Transaction::TokenBurnV1 { .. } => println!("TokenBurnV1"),
         _ => println!("Didn't find TokenBurnV1"),
     }
 
-    let routing_v1 = transactions::get(&client, "D5M1wmQNWQm9DqzatDf3MfNrW9Eh2L6vYjfmVDqoS7M").await.unwrap();
+    let routing_v1 = transactions::get(&client, "D5M1wmQNWQm9DqzatDf3MfNrW9Eh2L6vYjfmVDqoS7M")
+        .await
+        .unwrap();
     match routing_v1 {
         Transaction::RoutingV1 { .. } => println!("Found RoutingV1"),
         _ => println!("Didn't find RoutingV1"),
     }
 
-    let oui_v1 = transactions::get(&client, "7fl-fxx0FKHDB0owBnxybc5GlkFakbTbUbrmC2pxttY").await.unwrap();
+    let oui_v1 = transactions::get(&client, "7fl-fxx0FKHDB0owBnxybc5GlkFakbTbUbrmC2pxttY")
+        .await
+        .unwrap();
     match oui_v1 {
         Transaction::OuiV1 { .. } => println!("OuiV1"),
         _ => println!("Didn't find OuiV1"),
     }
-
 }

--- a/examples/txn_types.rs
+++ b/examples/txn_types.rs
@@ -1,39 +1,40 @@
-use helium_jsonrpc::{blocks, Client, transactions};
+use helium_jsonrpc::{blocks, transactions, Client};
 
 //quick sanity check to make sure all transactions in the last 100 blocks can be serialized
 #[tokio::main]
 async fn main() {
-	let client = Client::new_with_base_url("http://localhost:4467".to_string());
-  let mut current_height = blocks::height(&client).await.unwrap();
-  let start_height = current_height;
-  println!("Height: {}", start_height);
+    let client = Client::new_with_base_url("http://localhost:4467".to_string());
+    let mut current_height = blocks::height(&client).await.unwrap();
+    let start_height = current_height;
+    println!("Height: {}", start_height);
 
-  let mut types: Vec<String> = Vec::new();
+    let mut types: Vec<String> = Vec::new();
 
-  loop {
-  	let block = match blocks::get_raw(&client, &current_height).await {
-  		Ok(b) => b,
-  		Err(e) => panic!("Couldn't get block {}. {}", current_height, e),
-  	};
+    loop {
+        let block = match blocks::get_raw(&client, &current_height).await {
+            Ok(b) => b,
+            Err(e) => panic!("Couldn't get block {}. {}", current_height, e),
+        };
 
-    for txn in block.transactions {
-      match transactions::get(&client, &txn.hash.to_string()).await {
-        Ok(_t) => types.push(txn.r#type),
-        Err(e) => println!("Error getting txn {}. Type: {}, error: {}", txn.hash, txn.r#type, e),
-      };
+        for txn in block.transactions {
+            match transactions::get(&client, &txn.hash.to_string()).await {
+                Ok(_t) => types.push(txn.r#type),
+                Err(e) => println!(
+                    "Error getting txn {}. Type: {}, error: {}",
+                    txn.hash, txn.r#type, e
+                ),
+            };
+        }
+
+        if start_height - current_height >= 100 {
+            break;
+        }
+
+        current_height -= 1;
     }
 
-  	if start_height - current_height >= 100 {
-  		break;
-  	}
+    types.sort();
+    types.dedup();
 
-  	current_height -= 1;
-  }
-
-  types.sort();
-  types.dedup();
-
-  println!("{:?}", types);
-
-
+    println!("{:?}", types);
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -23,7 +23,7 @@ pub enum Error {
     #[error("error deserializing JSON response")]
     JsonDeserialization(#[from] serde_json::Error),
     #[error("node response with no error but no result")]
-    NodeResponseNoResult
+    NodeResponseNoResult,
 }
 
 impl Error {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,6 @@ impl Client {
         let request = self.client.post(&request_url).json(&data);
         let response = request.send().await?;
         let body = response.text().await?;
-        println!("{}", body);
         let v: Response<T> = serde_json::from_str(&body)?;
         match v {
             Response::Data { result, .. } => Ok(result),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,6 @@ impl Client {
         let request = self.client.post(&request_url).json(&data);
         let response = request.send().await?;
         let body = response.text().await?;
-
         let v: Response<T> = serde_json::from_str(&body)?;
         match v {
             Response::Data { result, .. } => Ok(result),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,6 +66,7 @@ impl Client {
         let request = self.client.post(&request_url).json(&data);
         let response = request.send().await?;
         let body = response.text().await?;
+        println!("{}", body);
         let v: Response<T> = serde_json::from_str(&body)?;
         match v {
             Response::Data { result, .. } => Ok(result),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,7 @@ impl Client {
         let request = self.client.post(&request_url).json(&data);
         let response = request.send().await?;
         let body = response.text().await?;
-
+        println!("{:?}", body);
         let v: Response<T> = serde_json::from_str(&body)?;
         match v {
             Response::Data { result, .. } => Ok(result),
@@ -94,7 +94,6 @@ enum Method {
     TransactionGet { params: TransactionParam },
 }
 
-
 #[derive(Clone, Deserialize, Debug, Serialize)]
 pub(crate) struct NodeCall {
     jsonrpc: String,
@@ -116,22 +115,26 @@ impl NodeCall {
     }
 
     pub(crate) fn block(height: u64) -> Self {
-        Self::new( Method::BlockGet { params: BlockParams { height }})
+        Self::new(Method::BlockGet {
+            params: BlockParams { height },
+        })
     }
 
     pub(crate) fn transaction(hash: String) -> Self {
-        Self::new(Method::TransactionGet { params: TransactionParam { hash }})
+        Self::new(Method::TransactionGet {
+            params: TransactionParam { hash },
+        })
     }
 }
 
 #[derive(Clone, Deserialize, Debug, Serialize)]
 struct BlockParams {
-    height: u64
+    height: u64,
 }
 
 #[derive(Clone, Deserialize, Debug, Serialize)]
 struct TransactionParam {
-    hash: String
+    hash: String,
 }
 
 #[async_trait]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,7 @@ impl Client {
         let request = self.client.post(&request_url).json(&data);
         let response = request.send().await?;
         let body = response.text().await?;
-        println!("{:?}", body);
+
         let v: Response<T> = serde_json::from_str(&body)?;
         match v {
             Response::Data { result, .. } => Ok(result),

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -14,7 +14,7 @@ pub struct Witness {
     pub datarate: String,
     pub frequency: f64,
     pub gateway: String,
-    pub is_valid: bool,
+    pub is_valid: Option<bool>,
     pub packet_hash: String,
     pub signal: i64,
     pub snr: f64,
@@ -289,6 +289,15 @@ pub enum Transaction {
         payment_amount: u64,
         stake_amount: u64,
     },
+    UnstakeValidatorV1 {
+        address: String,
+        owner: String,
+        owner_signature: String,
+        fee: u64,
+        stake_amount: u64,
+        stake_release_height: u64,
+        hash: String,
+    },
     // no examples found on blockchain. inferred from proto source code
     CoinbaseV1 {
         hash: String,
@@ -482,7 +491,7 @@ mod test {
 
         let txn = transactions::get(&client, "EjL6nBsSxovJluW-kdAaPcEiRt0OPIATOmlHD1Lth4Y")
             .await
-            .expect("RoutingV1");
+            .expect("RoutingV1_NewXor");
 
         if let Transaction::RoutingV1 {
             fee: _,
@@ -493,7 +502,7 @@ mod test {
             action,
         } = txn
         {
-            assert_eq!(oui, 12,);
+            assert_eq!(oui, 12);
             assert_eq!(
                 owner,
                 "112ewJNEUfSg3Jvo276tMjzFC2JzmmZcJJ32CWz2fzYqbyCMMTe1",
@@ -503,6 +512,32 @@ mod test {
             } else {
                 assert!(false)
             }
+        } else {
+            assert!(false)
+        }
+    }
+
+    #[test]
+    async fn unstake_validator_v1() {
+        let client = Client::default();
+
+        let txn = transactions::get(&client, "fMT-7_f2WQNKAYIQWX2-V258KsoI61HYbt_zAbN3A1I")
+            .await
+            .expect("UnstakeValidatorv1");
+
+        if let Transaction::UnstakeValidatorV1 {
+            address,
+            owner: _owner,
+            owner_signature: _own_signature,
+            fee,
+            stake_amount,
+            stake_release_height: _stake_release_height,
+            hash: _hash,
+        } = txn
+        {
+            assert_eq!(address, "11cY9Ly5H3hU4Ai2k7G9niHLAxsKb1ragQYGLJ7E9vh4Vnx6Efb");
+            assert_eq!(stake_amount, 1000000000000);
+            assert_eq!(fee, 35000);
         } else {
             assert!(false)
         }

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -52,19 +52,10 @@ pub struct Reward {
 #[derive(Clone, Serialize, Deserialize, Debug)]
 #[serde(tag = "action", rename_all = "snake_case")]
 pub enum RoutingAction {
-    NewXor {
-        filter: String,
-    },
-    UpdateXor {
-        filter: String,
-        index: usize,
-    },
-    UpdateRouters {
-        addresses: Vec<String>,
-    },
-    RequestSubnet {
-        requested_subnet_size: u64,
-    },
+    NewXor { filter: String },
+    UpdateXor { filter: String, index: usize },
+    UpdateRouters { addresses: Vec<String> },
+    RequestSubnet { requested_subnet_size: u64 },
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
@@ -342,11 +333,10 @@ mod test {
         let txn = transactions::get(&client, "1gidN7e6OKn405Fru_0sGhsqca3lTsrfGKrM4dwM_E8")
             .await
             .expect("PocRequestV1");
-        match txn {
-            Transaction::PocRequestV1 { block_hash, .. } => {
-                assert_eq!(block_hash, "RS2mBvd_4pbKCglkkyMroDQekPNO0xDdYx6Te3HGDGg")
-            }
-            _ => (),
+        if let Transaction::PocRequestV1 { block_hash, .. } = txn {
+            assert_eq!(block_hash, "RS2mBvd_4pbKCglkkyMroDQekPNO0xDdYx6Te3HGDGg")
+        } else {
+            assert!(false)
         }
     }
     #[test]
@@ -355,11 +345,10 @@ mod test {
         let txn = transactions::get(&client, "yh01SJk8dvyqb-BGXxkHFUuLi6wF1pfL0VEFStJUt-E")
             .await
             .expect("ConsensusGroupV1");
-        match txn {
-            Transaction::ConsensusGroupV1 { hash, .. } => {
-                assert_eq!(hash, "yh01SJk8dvyqb-BGXxkHFUuLi6wF1pfL0VEFStJUt-E")
-            }
-            _ => panic!("Didn't find ConsensusGroupV1"),
+        if let Transaction::ConsensusGroupV1 { hash, .. } = txn {
+            assert_eq!(hash, "yh01SJk8dvyqb-BGXxkHFUuLi6wF1pfL0VEFStJUt-E")
+        } else {
+            assert!(false)
         }
     }
     #[test]
@@ -369,9 +358,10 @@ mod test {
         let txn = transactions::get(&client, "C_jJZLKBOv_gRQ6P6wEpZPiRVAjf44FOx1iHOFD4haA")
             .await
             .expect("PaymentV2");
-        match txn {
-            Transaction::PaymentV2 { payments, .. } => assert_eq!(payments.len(), 1),
-            _ => (),
+        if let Transaction::PaymentV2 { payments, .. } = txn {
+            assert_eq!(payments.len(), 1)
+        } else {
+            assert!(false)
         }
     }
     #[test]
@@ -380,24 +370,23 @@ mod test {
         let txn = transactions::get(&client, "8RaF-G4pvMVuIXfBYhdqNuIlFSEHPm_rC8TH-h4JYdE")
             .await
             .expect("PocReceipt");
-        match txn {
-            Transaction::PocReceiptsV1 { hash, .. } => {
-                assert_eq!(hash, "8RaF-G4pvMVuIXfBYhdqNuIlFSEHPm_rC8TH-h4JYdE")
-            }
-            _ => (),
+        if let Transaction::PocReceiptsV1 { hash, .. } = txn {
+            assert_eq!(hash, "8RaF-G4pvMVuIXfBYhdqNuIlFSEHPm_rC8TH-h4JYdE")
+        } else {
+            assert!(false)
         }
     }
+
     #[test]
     async fn payment_v1() {
         let client = Client::default();
         let txn = transactions::get(&client, "iMSckt_hUcMFY_d7W-QOupY0MGq_g3-CC2dq3P-HWIw")
             .await
             .expect("PaymentV1");
-        match txn {
-            Transaction::PaymentV1 { payee, .. } => {
-                assert_eq!(payee, "14YeKFGXE23yAdACj6hu5NWEcYzzKxptYbm5jHgzw9A1P1UQfMv")
-            }
-            _ => (),
+        if let Transaction::PaymentV1 { payee, .. } = txn {
+            assert_eq!(payee, "14YeKFGXE23yAdACj6hu5NWEcYzzKxptYbm5jHgzw9A1P1UQfMv")
+        } else {
+            assert!(false)
         }
     }
     #[test]
@@ -406,9 +395,10 @@ mod test {
         let txn = transactions::get(&client, "X0HNRGZ1HAX51CR8qS6LTopAosjFkuaaKXl850IpNDE")
             .await
             .expect("RewardsV2");
-        match txn {
-            Transaction::RewardsV2 { rewards, .. } => assert_eq!(rewards.len(), 10138),
-            _ => (),
+        if let Transaction::RewardsV2 { rewards, .. } = txn {
+            assert_eq!(rewards.len(), 10138)
+        } else {
+            assert!(false)
         }
     }
     #[test]
@@ -417,11 +407,10 @@ mod test {
         let txn = transactions::get(&client, "_I16bycHeltuOo7eyqa4uhv2Bc7awcztZflyvRkVZ24")
             .await
             .expect("AssertLocationV1");
-        match txn {
-            Transaction::AssertLocationV1 { hash, .. } => {
-                assert_eq!(hash, "_I16bycHeltuOo7eyqa4uhv2Bc7awcztZflyvRkVZ24")
-            }
-            _ => (),
+        if let Transaction::AssertLocationV1 { hash, .. } = txn {
+            assert_eq!(hash, "_I16bycHeltuOo7eyqa4uhv2Bc7awcztZflyvRkVZ24")
+        } else {
+            assert!(false)
         }
     }
     #[test]
@@ -430,12 +419,13 @@ mod test {
         let txn = transactions::get(&client, "TfjRv733Q9FBQ1_unw1c9g5ewVmMBuyf7APuyxKEqrw")
             .await
             .expect("AssertLocationV2");
-        match txn {
-            Transaction::AssertLocationV2 { gateway, .. } => assert_eq!(
+        if let Transaction::AssertLocationV2 { gateway, .. } = txn {
+            assert_eq!(
                 gateway,
                 "112WVxXCrCjiKmmDXLDUJuhYGEHMbXobUZe8oJQkHoMHEFa149a"
-            ),
-            _ => (),
+            )
+        } else {
+            assert!(false)
         }
     }
     #[test]
@@ -444,33 +434,51 @@ mod test {
         let txn = transactions::get(&client, "aoTggHSgaBAamuUUrXnY42jDZ5WUBxE0k-tshvfn35E")
             .await
             .expect("AddGatewayV1");
-        match txn {
-            Transaction::AddGatewayV1 { gateway, .. } => assert_eq!(
+        if let Transaction::AddGatewayV1 { gateway, .. } = txn {
+            assert_eq!(
                 gateway,
                 "112uuvztDziVQyLVvBxMsovsSPV5ZXkN6uQ5hrWSaWwV1oEZTZtd"
-            ),
-            _ => (),
+            )
+        } else {
+            assert!(false)
         }
     }
+
+    #[test]
+    async fn add_gateway_v1_error() {
+        let client = Client::default();
+        let txn = transactions::get(&client, "ia3c386ZnlVJorvo60WtXEFxy_0w35ImoIdmnW5lpJ8")
+            .await
+            .expect("AddGatewayV1");
+        if let Transaction::AddGatewayV1 { gateway, .. } = txn {
+            assert_eq!(
+                gateway,
+                "112uuvztDziVQyLVvBxMsovsSPV5ZXkN6uQ5hrWSaWwV1oEZTZtd"
+            )
+        } else {
+            assert!(false)
+        }
+    }
+
     #[test]
     async fn transfer_hotspot_v1() {
         let client = Client::default();
         let txn = transactions::get(&client, "fSFua7A8G41K05QXAvJi5N2OB0QqmQ7xp7u-My4rYHc")
             .await
             .expect("TransferHotspotV1");
-        match txn {
-            Transaction::TransferHotspotV1 { seller, .. } => assert_eq!(
+        if let Transaction::TransferHotspotV1 { seller, .. } = txn {
+            assert_eq!(
                 seller,
                 "14mo9fFGKYFaWh7xscpDLg7misWcuU5xqR8mc8gHr4c43nDnzeX"
-            ),
-            _ => (),
+            )
+        } else {
+            assert!(false)
         }
     }
 
     #[test]
     async fn transfer_routing_v1_new_xor() {
-        //let client = Client::default();
-        let client = Client::new_with_base_url("http://127.0.0.1:4467".into());
+        let client = Client::default();
 
         let txn = transactions::get(&client, "EjL6nBsSxovJluW-kdAaPcEiRt0OPIATOmlHD1Lth4Y")
             .await


### PR DESCRIPTION
Routing Txn for NewXor was not parsing so I made some changes there.

The examples had not been upkept with a recent change to the BlockTxn type.

The test design was lacking insofar as many failures would have been green due to not throwing `assert!(false)` for the unexpected match cases.

I accidentally did a `cargo fmt` on the whole project but it would've been a bit of work to revert so I left it in.