### PR TITLE
create custom TransactionProcessing error

### DIFF
--- a/src/blocks.rs
+++ b/src/blocks.rs
@@ -24,7 +24,12 @@ impl BlockRaw {
     pub async fn get_transactions(&self, client: &Client) -> Result<Vec<Transaction>> {
         let mut txns: Vec<Transaction> = Vec::new();
         for txn in &self.transactions {
-            txns.push(transactions::get(client, &txn.hash).await?);
+            txns.push(transactions::get(client, &txn.hash).await.map_err(|_| {
+                Error::TransactionProcessing {
+                    r#type: txn.r#type.clone(),
+                    hash: txn.hash.clone(),
+                }
+            })?);
         }
         Ok(txns)
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,12 +2,6 @@ use thiserror::Error;
 
 pub type Result<T = ()> = std::result::Result<T, Error>;
 
-#[derive(Clone, Debug)]
-pub(crate) struct ErrorElement {
-    message: String,
-    code: i32,
-}
-
 #[derive(Error, Debug)]
 pub enum Error {
     #[error("request error")]
@@ -22,6 +16,8 @@ pub enum Error {
     NodeError(String, isize),
     #[error("error deserializing JSON response")]
     JsonDeserialization(#[from] serde_json::Error),
+    #[error("error deserializing transaction of type {r#type} and hash {hash}")]
+    TransactionProcessing { r#type: String, hash: String },
     #[error("node response with no error but no result")]
     NodeResponseNoResult,
 }


### PR DESCRIPTION
This customizes the handling of a failed `transaction::get` call so that the user receives the transaction type and hash. This can help a user ignore the error and also helps developers resolve the error (usually due to JSON deserialization not matching what the blockchain-node returns).

Also, some dead_code relating to ErrorElements is removed.