### PR TITLE
REST consistency

### DIFF
--- a/src/accounts.rs
+++ b/src/accounts.rs
@@ -34,7 +34,7 @@ mod test {
     #[test]
     async fn get_account() {
         let client = Client::default();
-        let account = account::get(
+        let account = accounts::get(
             &client,
             "1be3xdTQTYX8UbA5ND5F1cKcGEw1BSD2akyFtXbJkxDm5JtLzzD",
         )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@ pub use helium_api::models::{
 pub mod error;
 
 pub use error::{Error, Result};
-pub mod account;
+pub mod accounts;
 pub mod blocks;
 pub mod oracle;
 pub mod transactions;

--- a/src/oracle.rs
+++ b/src/oracle.rs
@@ -6,10 +6,15 @@ struct PriceCurrentResult {
     price: Usd,
 }
 
-/// Submit a transaction in base64
-pub async fn price_current(client: &Client) -> Result<(u64, Usd)> {
-    let json = NodeCall::oracle_price_current();
-    let url_path = "/";
-    let result: PriceCurrentResult = client.post(url_path, &json).await?;
-    Ok((result.height, result.price))
+
+
+pub mod prices {
+    use super::*;
+    
+    pub async fn current(client: &Client) -> Result<(u64, Usd)> {
+        let json = NodeCall::oracle_price_current();
+        let url_path = "/";
+        let result: PriceCurrentResult = client.post(url_path, &json).await?;
+        Ok((result.height, result.price))
+    }
 }

--- a/src/oracle.rs
+++ b/src/oracle.rs
@@ -6,11 +6,9 @@ struct PriceCurrentResult {
     price: Usd,
 }
 
-
-
 pub mod prices {
     use super::*;
-    
+
     pub async fn current(client: &Client) -> Result<(u64, Usd)> {
         let json = NodeCall::oracle_price_current();
         let url_path = "/";


### PR DESCRIPTION
While plugging in helium-jsonrpc as a replacement for helium-api, I realized there had been some unnecessary drift in the helium-jsonrpc API, which should try to maintain consistency with helium-api.